### PR TITLE
[WIP] Improvement for parsing multiple slides

### DIFF
--- a/markdown-it-decksetter.js
+++ b/markdown-it-decksetter.js
@@ -38,13 +38,11 @@ module.exports = function containerPlugin (md, name, options) {
     var max = state.eMarks[startLine] // the index of the last character of a line
 
     // if this is the first iteration and the marker is not found, this is the first slide
-    if (markerChar !== state.src.charCodeAt(start)) {
+    if (start === 0) {
+      isTop = true
+    } else if (markerChar !== state.src.charCodeAt(start)) {
       // if markerChar is not at the beginning of the line, skip to the next line
-      if (start === 0) {
-        isTop = true
-      } else {
-        return false
-      }
+      return false
     }
 
     if (isTop) {
@@ -109,11 +107,11 @@ module.exports = function containerPlugin (md, name, options) {
         continue
       }
 
-      for (position = start + 1; position <= max; position++) {
+      /*for (position = start + 1; position <= max; position++) {
         if (markerStr[(position - start) % markerLen] !== state.src[position]) {
           break
         }
-      }
+      }*/
 
       // closing code fence must be at least as long as the opening one
       if (Math.floor((position - start) / markerLen) < markerCount) {


### PR DESCRIPTION
Through some deduction and reading the `markdown-it-container` source, I was able to at least get a closing `</article>` element to appear for every slide that's present &mdash; they're just not positioned properly.

```
$ node bin/decksite.js run test/test-notes/three-slides.md 
<article class="slides">
<p>this is the first slide</p>
<p>^ here are some notes</p>
<article class="slides">
<h1>the second slide</h1>
<p>this is the second slide</p>
<p>^ here are some more notes</p>
<article class="slides">
<h1>the third slide</h1>
<p>hi i am a third slide</p>
<p>^ whoa even more notes</p>
</article>
</article>
</article>
```

If you add `state.push('debug', '!-- --', 1);` right before `token = state.push('container_slide_open', 'article', 1)` you'll get a clearer picture at what's happening.

```
<!-- -->
<article class="slides">
<p>this is the first slide</p>
<p>^ here are some notes</p>
<!-- -->
<article class="slides">
<h1>the second slide</h1>
<p>this is the second slide</p>
<p>^ here are some more notes</p>
<!-- -->
<article class="slides">
<h1>the third slide</h1>
<p>hi i am a third slide</p>
<p>^ whoa even more notes</p>
</article>
</article>
</article>
```

With these changes, I've come to a (possible?) conclusion, that the problem is that `nextLine` isn't pointing to the right pointer. I'm not sure though, lol.

I actually ended up trying to just junk all this and splitting `state.src` on `/-{3}\n/im` (accounts for exactly 3 `-`, but could be easily modified to allow 3+), and then tokenizing each of the matches within `<article>` tags, but I couldn't find the right markdown-it internal API for tokenizing a string of Markdown.

So hopefully all of this helps, somehow. Programming is hard.
